### PR TITLE
disable ace-dt formula and point to cask

### DIFF
--- a/Formula/ace-dt.rb
+++ b/Formula/ace-dt.rb
@@ -7,6 +7,7 @@ class AceDt < Formula
   homepage "https://github.com/act3-ai/data-tool"
   version "1.15.33"
   license "MIT"
+  disable! date: "2025-07-15", because: "the cask should be used now instead", replacement_cask: "ace-dt"
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
goreleaser has deprecated their brew formula creation, opting to switch to a cask